### PR TITLE
Fix broken og:images

### DIFF
--- a/_posts/2019-03-24-bair-commons.md
+++ b/_posts/2019-03-24-bair-commons.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Announcing the BAIR Open Research Commons"
 date:               2019-03-24 9:00:00
 author:             ""
-img:                assets/bair-commons/berkeley_way-west_web_1.jpg
+img:                /assets/bair-commons/berkeley_way-west_web_1.jpg
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2019-03-27-cvpr-competition.md
+++ b/_posts/2019-03-27-cvpr-competition.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "CVPR 2019 Challenges on Domain Adaptation in Autonomous Driving"
 date:               2019-03-27 9:00:00
 author:             <a href="https://www.yf.io/">Fisher Yu</a>
-img:                assets/BAIR_Logo.png
+img:                /assets/BAIR_Logo.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-04-11-tools.md
+++ b/_posts/2019-04-11-tools.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Robots that Learn to Use Improvised Tools"
 date:               2019-04-11 9:00:00
 author:             Annie Xie
-img:                assets/tools/chimp.jpg
+img:                /assets/tools/chimp.jpg
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-05-06-robot-adapt.md
+++ b/_posts/2019-05-06-robot-adapt.md
@@ -4,7 +4,7 @@ title:              "Robots that Learn to Adapt"
 date:               2019-05-06 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~nagaban2/">Anusha Nagabandi</a> and
                     <a href="https://iclavera.github.io/">Ignasi Clavera</a><br>
-img:                assets/adapt/teaser.png
+img:                /assets/adapt/teaser.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-05-13-oltr.md
+++ b/_posts/2019-05-13-oltr.md
@@ -4,7 +4,7 @@ title:              "Large-Scale Long-Tailed Recognition in an Open World"
 date:               2019-05-13 9:00:00
 author:             <a href="https://github.com/zhmiao">Zhongqi Miao</a> and
                     <a href="https://liuziwei7.github.io/">Ziwei Liu</a><br>
-img:                assets/oltr/teaser.png
+img:                /assets/oltr/teaser.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-05-20-solar.md
+++ b/_posts/2019-05-20-solar.md
@@ -4,7 +4,7 @@ title:              "Model-Based Reinforcement Learning from Pixels with Structu
 date:               2019-05-20 9:00:00
 author:             <a href="http://marvinzhang.com/">Marvin Zhang</a> and
                     <a href="http://www.sharadvikram.com/">Sharad Vikram</a><br>
-img:                assets/solar/exp.png
+img:                /assets/solar/exp.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-05-28-end-to-end.md
+++ b/_posts/2019-05-28-end-to-end.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "End-to-End Deep Reinforcement Learning <br> without Reward Engineering"
 date:               2019-05-28 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~avisingh/">Avi Singh</a>
-img:                assets/end_to_end/vice_raq_teaser.png
+img:                /assets/end_to_end/vice_raq_teaser.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-06-03-benchmarks.md
+++ b/_posts/2019-06-03-benchmarks.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Autonomous Vehicles for Social Good: Learning to Solve Congestion"
 date:               2019-06-03 9:00:00
 author:             Eugene Vinitsky
-img:                assets/benchmarks/figure_eight.png
+img:                /assets/benchmarks/figure_eight.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-06-07-data_aug.md
+++ b/_posts/2019-06-07-data_aug.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "1000x Faster Data Augmentation"
 date:               2019-06-07 9:00:00
 author:             Daniel Ho, Eric Liang, Richard Liaw
-img:                assets/data_aug/augmentation_schedule_viz.png
+img:                /assets/data_aug/augmentation_schedule_viz.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-06-10-pearl.md
+++ b/_posts/2019-06-10-pearl.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Learning to Learn with Probabilistic Task Embeddings"
 date:               2019-06-10 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~rakelly/">Kate Rakelly</a>
-img:                assets/pearl/5_meta_training.jpg
+img:                /assets/pearl/5_meta_training.jpg
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-08-13-memorization.md
+++ b/_posts/2019-08-13-memorization.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Evaluating and Testing Unintended Memorization in Neural Networks"
 date:               2019-08-13 12:00:00
 author:             Nicholas Carlini
-img:                assets/memorization/mem_over_train_short.png
+img:                /assets/memorization/mem_over_train_short.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-09-19-bit-swap.md
+++ b/_posts/2019-09-19-bit-swap.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "A Deep Learning Approach to Data Compression"
 date:               2019-09-19 9:00:00
 author:             <a href="https://www.fhkingma.com/">Friso Kingma</a>
-img:                assets/bit_swap/BitSwap-1.png
+img:                /assets/bit_swap/BitSwap-1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-09-24-rlpyt.md
+++ b/_posts/2019-09-24-rlpyt.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "rlpyt: A Research Code Base for Deep Reinforcement Learning in PyTorch"
 date:               2019-09-24 9:00:00
 author:             Adam Stooke
-img:                assets/rlpyt/samplers.png
+img:                /assets/rlpyt/samplers.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-09-26-circuits.md
+++ b/_posts/2019-09-26-circuits.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Sample Efficient Evolutionary Algorithm for Analog Circuit Design"
 date:               2019-09-26 9:00:00
 author:             Kourosh Hakhamaneshi
-img:                assets/circuits/1.png
+img:                /assets/circuits/1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-09-30-deep-dynamics.md
+++ b/_posts/2019-09-30-deep-dynamics.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Deep Dynamics Models for Dexterous Manipulation"
 date:               2019-09-30 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~nagaban2/">Anusha Nagabandi</a>
-img:                assets/deep-dynamics/image10.png
+img:                /assets/deep-dynamics/image10.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-10-14-functional-rl.md
+++ b/_posts/2019-10-14-functional-rl.md
@@ -5,7 +5,7 @@ date:               2019-10-14 9:00:00
 author:             <a href="https://www.linkedin.com/in/eric-liang-31308019/">Eric Liang</a> and
                     <a href="http://people.eecs.berkeley.edu/~rliaw/">Richard Liaw</a> and
                     <a href="http://people.csail.mit.edu/gehring/">Clement Gehring</a>
-img:                assets/functional/rl_lib.png
+img:                /assets/functional/rl_lib.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-10-21-coordination.md
+++ b/_posts/2019-10-21-coordination.md
@@ -4,7 +4,7 @@ title:              "Collaborating with Humans Requires Understanding Them"
 date:               2019-10-21 9:00:00
 author:             <a href="https://rohinshah.com">Rohin Shah</a> and
                     <a href="https://micahcarroll.github.io/">Micah Carroll</a>
-img:                assets/coordination/8_Training_Diagram.png
+img:                /assets/coordination/8_Training_Diagram.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-10-28-look-then-listen.md
+++ b/_posts/2019-10-28-look-then-listen.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Look then Listen: Pre-Learning Environment Representations for Data-Efficient Neural Instruction Following"
 date:               2019-10-28 9:00:00
 author:             <a href="https://dgaddy.github.io/">David Gaddy</a>
-img:                assets/look-then-listen/training_example.PNG
+img:                /assets/look-then-listen/training_example.PNG
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-11-04-proteins.md
+++ b/_posts/2019-11-04-proteins.md
@@ -5,7 +5,7 @@ date:               2019-11-04 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~nthomas/">Neil Thomas</a>,
                     <a href="https://nickbhat.github.io/">Nicholas Bhattacharya</a>, and
                     <a href="https://rmrao.github.io/">Roshan Rao</a><br>
-img:                assets/tape/proteins_xkcd.png
+img:                /assets/tape/proteins_xkcd.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-11-22-anca.md
+++ b/_posts/2019-11-22-anca.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Prof. Anca Dragan Talks About Human-Robot Interaction for WIRED"
 date:               2019-11-22 9:00:00
 author:             ""
-img:                assets/anca/anca.png
+img:                /assets/anca/anca.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-11-26-robo-net.md
+++ b/_posts/2019-11-26-robo-net.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "RoboNet: A Dataset for Large-Scale Multi-Robot Learning"
 date:               2019-11-26 9:00:00
 author:             <a href="https://sudeepdasari.github.io">Sudeep Dasari</a>
-img:                assets/robonet/hypothesis.png
+img:                /assets/robonet/hypothesis.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-12-05-bear.md
+++ b/_posts/2019-12-05-bear.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Data-Driven Deep Reinforcement Learning"
 date:               2019-12-05 9:00:00
 author:             <a href="https://aviralkumar2907.github.io/">Aviral Kumar</a>
-img:                assets/bear/bear.png
+img:                /assets/bear/bear.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-12-12-mbpo.md
+++ b/_posts/2019-12-12-mbpo.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Model-Based Reinforcement Learning:<br>Theory and Practice"
 date:               2019-12-12 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~janner/">Michael Janner</a>
-img:                assets/mbpo/teaser-01.png
+img:                /assets/mbpo/teaser-01.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-12-13-humans-cyclegan.md
+++ b/_posts/2019-12-13-humans-cyclegan.md
@@ -4,7 +4,7 @@ title:              "Learning to Imitate Human Demonstrations via CycleGAN"
 date:               2019-12-13 9:00:00
 author:             <a href="https://lauramsmith.github.io/">Laura Smith</a> and
                     <a href="http://marvinzhang.com/">Marvin Zhang</a>
-img:                assets/humans-cyclegan/setup.png
+img:                /assets/humans-cyclegan/setup.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-12-16-data-worth.md
+++ b/_posts/2019-12-16-data-worth.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "What is My Data Worth?"
 date:               2019-12-16 9:00:00
 author:             <a href="https://ruoxijia.github.io/">Ruoxi Jia</a>
-img:                assets/data-worth/1.png
+img:                /assets/data-worth/1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2019-12-18-smirl.md
+++ b/_posts/2019-12-18-smirl.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Emergent Behavior by Minimizing Chaos"
 date:               2019-12-18 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~gberseth/">Glen Berseth</a>
-img:                assets/smirl/SMiRL_Outline.png
+img:                /assets/smirl/SMiRL_Outline.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-01-16-tune.md
+++ b/_posts/2020-01-16-tune.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Large Scale Training at BAIR with Ray Tune"
 date:               2020-01-16 9:00:00
 author:             <a href="http://people.eecs.berkeley.edu/~rliaw/">Richard Liaw</a> and <a href="https://www.linkedin.com/in/eric-liang-31308019/">Eric Liang</a> and <a href="https://hartikainen.github.io/">Kristian Hartikainen</a>
-img:                assets/tune/tune-arch-simple.png
+img:                /assets/tune/tune-arch-simple.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-03-05-compress.md
+++ b/_posts/2020-03-05-compress.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Speeding Up Transformer Training and Inference By <i>Increasing</i> Model Size"
 date:               2020-03-05 9:00:00
 author:             <a href="https://www.ericswallace.com/">Eric Wallace</a>
-img:                assets/compress/Flowchart.png
+img:                /assets/compress/Flowchart.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-03-12-badgr.md
+++ b/_posts/2020-03-12-badgr.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "BADGR:<br>The Berkeley Autonomous Driving Ground Robot"
 date:               2020-03-12 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~gregoryk/">Greg Kahn</a>
-img:                assets/badgr/image_09.jpg
+img:                /assets/badgr/image_09.jpg
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-03-16-discor.md
+++ b/_posts/2020-03-16-discor.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Does On-Policy Data Collection Fix Errors in Off-Policy Reinforcement Learning?"
 date:               2020-03-16 9:00:00
 author:             <a href="https://aviralkumar2907.github.io/">Aviral Kumar</a> and <a href="https://people.eecs.berkeley.edu/~abhigupta/">Abhishek Gupta</a>
-img:                assets/discor/discor.png
+img:                /assets/discor/discor.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-03-27-attacks.md
+++ b/_posts/2020-03-27-attacks.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Physically Realistic Attacks on Deep Reinforcement Learning"
 date:               2020-03-27 9:00:00
 author:             <a href="https://gleave.me/">Adam Gleave</a>
-img:                assets/attacks/04_cycle.png
+img:                /assets/attacks/04_cycle.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-04-03-laikago.md
+++ b/_posts/2020-04-03-laikago.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Robots Learning to Move like Animals"
 date:               2020-04-03 9:00:00
 author:             <a href="https://xbpeng.github.io/">Xue Bin (Jason) Peng</a>
-img:                assets/laikago/02_keypoints_robot.png
+img:                /assets/laikago/02_keypoints_robot.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-04-23-decisions.md
+++ b/_posts/2020-04-23-decisions.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Making Decision Trees Accurate Again: Explaining What Explainable AI Did Not"
 date:               2020-04-23 9:00:00
 author:             <a href="https://alvinwan.com">Alvin Wan</a>
-img:                assets/decisions/decision_Trees.jpeg
+img:                /assets/decisions/decision_Trees.jpeg
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-04-27-ingredients.md
+++ b/_posts/2020-04-27-ingredients.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "The Ingredients of Real World Robotic Reinforcement Learning"
 date:               2020-04-27 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~abhigupta/">Abhishek Gupta</a>, <a href="https://henryzhu.xyz/">Henry Zhu</a>, <a href="https://justinvyu.github.io/about/">Justin Yu</a>, <a href="https://vikashplus.github.io/">Vikash Kumar</a>, <a href="https://people.eecs.berkeley.edu/~shah/">Dhruv Shah</a>, <a href="https://people.eecs.berkeley.edu/~svlevine/">Sergey Levine</a><br>
-img:                assets/ingredients/03_ingredients_fig.png
+img:                /assets/ingredients/03_ingredients_fig.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-05-01-umrl.md
+++ b/_posts/2020-05-01-umrl.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Unsupervised Meta-Learning: Learning to Learn without Supervision"
 date:               2020-05-01 9:00:00
 author:             <a href="https://ben-eysenbach.github.io/">Benjamin Eysenbach</a> and <a href="https://people.eecs.berkeley.edu/~abhigupta/">Abhishek Gupta</a>
-img:                assets/umrl/umrl_teaser.png
+img:                /assets/umrl/umrl_teaser.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-05-05-fabrics.md
+++ b/_posts/2020-05-05-fabrics.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Four Novel Approaches to Manipulating Fabric using Model-Free and Model-Based Deep Learning in Simulation"
 date:               2020-05-05 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~seita/">Daniel Seita</a>, <a href="https://wilson1yan.github.io/">Wilson Yan</a>, <a href="https://ryanhoque.github.io/">Ryan Hoque</a>
-img:                assets/fabrics/daniel_traj_corners_analytic_v04.png
+img:                /assets/fabrics/daniel_traj_corners_analytic_v04.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-05-14-omnitact.md
+++ b/_posts/2020-05-14-omnitact.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "OmniTact: A Multi-Directional High-Resolution Touch Sensor"
 date:               2020-05-14 9:00:00
 author:             <a href="https://akhilpadmanabha.wixsite.com/portfolio/about">Akhil Padmanabha</a> and <a href="https://febert.github.io/">Frederik Ebert</a>
-img:                assets/omnitact/Fig1.png
+img:                /assets/omnitact/Fig1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-06-14-ocda.md
+++ b/_posts/2020-06-14-ocda.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Open Compound Domain Adaptation"
 date:               2020-06-14 9:00:00
 author:             <a href="https://github.com/zhmiao">Zhongqi Miao</a> and <a href="https://liuziwei7.github.io/">Ziwei Liu</a>
-img:                assets/ocda/figure_1.jpg
+img:                /assets/ocda/figure_1.jpg
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-06-25-D4RL.md
+++ b/_posts/2020-06-25-D4RL.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "D4RL: Building Better Benchmarks for Offline Reinforcement Learning"
 date:               2020-06-25 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~justinjfu/">Justin Fu</a>
-img:                assets/d4rl/maze2d_medium.gif
+img:                /assets/d4rl/maze2d_medium.gif
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-07-11-auction.md
+++ b/_posts/2020-07-11-auction.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Decentralized Reinforcement Learning:<br>Global Decision-Making via<br>Local Economic Transactions"
 date:               2020-07-11 9:00:00
 author:             <a href="http://mbchang.github.io/">Michael Chang</a> and <a href="https://www.linkedin.com/in/sid-k-232763a6/">Sidhant Kaushik</a>
-img:                assets/auction/mnist.png
+img:                /assets/auction/mnist.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-07-19-curl-rad.md
+++ b/_posts/2020-07-19-curl-rad.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Can RL From Pixels be as Efficient as RL From State?"
 date:               2020-07-19 9:00:00
 author:             <a href="https://mishalaskin.github.io/">Misha Laskin</a>, <a href="https://people.eecs.berkeley.edu/~aravind/">Aravind Srinivas</a>, <a href="https://sites.google.com/view/kiminlee">Kimin Lee</a>, <a href="https://www.linkedin.com/in/adam-stooke-06bb6923/">Adam Stooke</a>, <a href="https://cs.nyu.edu/~lp91/">Lerrel Pinto</a>, <a href="https://people.eecs.berkeley.edu/~pabbeel/">Pieter Abbeel</a><br>
-img:                assets/curl/fig1.png
+img:                /assets/curl/fig1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-07-24-icm-kids.md
+++ b/_posts/2020-07-24-icm-kids.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Exploring Exploration: Comparing Children with RL Agents in Unified Environments"
 date:               2020-07-24 9:00:00
 author:             <a href="https://www.linkedin.com/in/eliza-kosoy-b3343293/">Eliza Kosoy</a>, <a href="http://j-collins.appspot.com/">Jasmine Collins</a> and <a href="https://people.eecs.berkeley.edu/~davidchan/">David Chan</a>
-img:                assets/icm/image4.png
+img:                /assets/icm/image4.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-08-03-covid-fatality.md
+++ b/_posts/2020-08-03-covid-fatality.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Estimating the fatality rate is difficult but doable with better data"
 date:               2020-08-03 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~angelopoulos/">Anastasios Angelopoulos</a>, <a href="https://people.eecs.berkeley.edu/~pathakr/">Reese Pathak</a>, and <a href="https://people.eecs.berkeley.edu/~jordan/">Michael Jordan</a>
-img:                assets/cfr/graphical-model.png
+img:                /assets/cfr/graphical-model.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-08-16-ai4all.md
+++ b/_posts/2020-08-16-ai4all.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "AI Will Change the World.<br>Who Will Change AI?<br>We Will."
 date:               2020-08-16 9:00:00
 author:             Sophia Stiles
-img:                assets/BAIR_Logo.png
+img:                /assets/BAIR_Logo.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2020-09-10-awac.md
+++ b/_posts/2020-09-10-awac.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "AWAC: Accelerating Online Reinforcement Learning with Offline Datasets"
 date:               2020-09-10 9:00:00
 author:             <a href="https://ashvin.me/">Ashvin Nair</a> and  <a href="https://people.eecs.berkeley.edu/~abhigupta/">Abhishek Gupta</a>
-img:                assets/awac/05_fig1.png
+img:                /assets/awac/05_fig1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-10-06-plan2explore.md
+++ b/_posts/2020-10-06-plan2explore.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Plan2Explore: Active Model-Building for Self-Supervised Visual Reinforcement Learning"
 date:               2020-10-06 9:00:00
 author:             <a href="https://www.seas.upenn.edu/~oleh/">Oleh Rybkin</a> and <a href="https://danijar.com/">Danijar Hafner</a> and <a href="https://www.cs.cmu.edu/~dpathak/">Deepak Pathak</a>
-img:                assets/plan2explore/plan2explore.png
+img:                /assets/plan2explore/plan2explore.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-10-13-supervised-rl.md
+++ b/_posts/2020-10-13-supervised-rl.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Reinforcement learning is supervised learning on optimized data"
 date:               2020-10-13 9:00:00
 author:             <a href="https://ben-eysenbach.github.io/">Ben Eysenbach</a> and <a href="https://aviralkumar2907.github.io/">Aviral Kumar</a> and <a href="https://people.eecs.berkeley.edu/~abhigupta/">Abhishek Gupta</a>
-img:                assets/supervised_rl/hipi.png
+img:                /assets/supervised_rl/hipi.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2020-11-05-arm.md
+++ b/_posts/2020-11-05-arm.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Adapting on the Fly to Test Time Distribution Shift"
 date:               2020-11-05 9:00:00
 author:             <a href="http://marvinzhang.com">Marvin Zhang</a>
-img:                assets/arm/methods.png
+img:                /assets/arm/methods.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2020-11-13-ridge-rider.md
+++ b/_posts/2020-11-13-ridge-rider.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Goodhart’s Law, Diversity and a Series of Seemingly Unrelated Toy Problems"
 date:               2020-11-13 9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~pacchiano/">Aldo Pacchiano</a>, Jack Parker-Holder, Luke Metz, and Jakob Foerster
-img:                assets/ridge-rider/fig02.png
+img:                /assets/ridge-rider/fig02.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2020-11-16-acnml.md
+++ b/_posts/2020-11-16-acnml.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Training on Test Inputs with Amortized Conditional Normalized Maximum Likelihood"
 date:               2020-11-16 9:00:00
 author:             Aurick Zhou
-img:                assets/acnml/fig6_alg_summary.JPG
+img:                /assets/acnml/fig6_alg_summary.JPG
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2020-11-18-evolvegraph.md
+++ b/_posts/2020-11-18-evolvegraph.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "EvolveGraph: Dynamic Neural Relational Reasoning for Interacting Systems"
 date:               2020-11-18 9:00:00
 author:             <a href="https://jiachenli94.github.io/">Jiachen Li</a>
-img:                assets/evolvegraph/figure2.png
+img:                /assets/evolvegraph/figure2.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2020-11-20-sgm.md
+++ b/_posts/2020-11-20-sgm.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Learning State Abstractions for Long-Horizon Planning"
 date:               2020-11-20 9:00:00
 author:             <a href="http://scottemmons.com/">Scott Emmons</a>*, <a href="https://www.ajayjain.net/">Ajay Jain</a>*, <a href="https://mishalaskin.github.io/">Michael Laskin</a>*, <a href="http://people.eecs.berkeley.edu/~thanard.kurutach/">Thanard Kurutach</a>, <a href="http://people.eecs.berkeley.edu/~pabbeel">Pieter Abbeel</a>, <a href="https://www.cs.cmu.edu/~dpathak/">Deepak Pathak</a><br>
-img:                assets/sgm/fig1.png
+img:                /assets/sgm/fig1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2020-12-20-lmmem.md
+++ b/_posts/2020-12-20-lmmem.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Does GPT-2 Know Your Phone Number?"
 date:               2020-12-20  9:00:00
 author:             <a href="https://www.ericswallace.com/">Eric Wallace</a>, <a href="https://floriantramer.com/">Florian Tramèr</a>, <a href="https://jagielski.github.io/">Matthew Jagielski</a>, and <a href="https://cyber.harvard.edu/people/ariel-herbert-voss">Ariel Herbert-Voss</a> <br />
-img:                assets/lmmem/fig1.png
+img:                /assets/lmmem/fig1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2020-12-7-offline.md
+++ b/_posts/2020-12-7-offline.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Offline Reinforcement Learning: How Conservative Algorithms Can Enable New Applications"
 date:               2020-12-07 9:00:00
 author:             <a href="https://aviralkumar2907.github.io/">Aviral Kumar</a> and <a href="http://avisingh.org">Avi Singh</a>
-img:                assets/offline/tease.png
+img:                /assets/offline/tease.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-01-01-example-post.md
+++ b/_posts/2021-01-01-example-post.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Example Post Title"
 date:               2021-01-01  9:00:00
 author:             <a href="">John Doe</a> and <a href="">Jane Doe</a>
-img:                assets/example_post/image1.png
+img:                /assets/example_post/image1.png
 excerpt_separator:  <!--more-->
 visible:            False
 show_comments:      False

--- a/_posts/2021-01-05-successor.md
+++ b/_posts/2021-01-05-successor.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "The Successor Representation, $\\gamma$-Models,<br> and Infinite-Horizon Prediction"
 date:               2021-01-05  9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~janner/">Michael Janner</a>
-img:                assets/successor/gamma-teaser.png
+img:                /assets/successor/gamma-teaser.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-02-25-ss-adaptation.md
+++ b/_posts/2021-02-25-ss-adaptation.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Self-Supervised Policy Adaptation during Deployment"
 date:               2021-02-25  9:00:00
 author:             <a href="https://nicklashansen.github.io/">Nicklas Hansen</a> and <a href="https://xiaolonw.github.io/">Xiaolong Wang</a>
-img:                assets/ss-adaptation/3_framework_1.png
+img:                /assets/ss-adaptation/3_framework_1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-03-10-maxent-robust-rl.md
+++ b/_posts/2021-03-10-maxent-robust-rl.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Maximum Entropy RL (Provably) Solves Some Robust RL Problems"
 date:               2021-03-09  9:00:00
 author:             Ben Eysenbach
-img:                assets/maxent-robust-rl/peg_maxent_screenshot.png
+img:                /assets/maxent-robust-rl/peg_maxent_screenshot.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-03-23-universal-computation.md
+++ b/_posts/2021-03-23-universal-computation.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Pretrained Transformers as Universal Computation Engines"
 date:               2021-03-23  9:00:00
 author:             <a href="https://kzl.github.io/">Kevin Lu</a>, <a href="https://aditya-grover.github.io/">Aditya Grover</a>, <a href="https://people.eecs.berkeley.edu/~pabbeel/">Pieter Abbeel</a>, and Igor Mordatch
-img:                assets/universal-computation/attention_visual.png
+img:                /assets/universal-computation/attention_visual.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-04-19-mbrl.md
+++ b/_posts/2021-04-19-mbrl.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "The Importance of Hyperparameter Optimization for Model-based Reinforcement Learning"
 date:               2021-04-19  9:00:00
 author:             <a href="https://www.natolambert.com/">Nathan Lambert</a>, <a href="https://nr.informatik.uni-freiburg.de/people/baohe-zhang">Baohe Zhang</a>, <a href="https://ml.informatik.uni-freiburg.de/people/rajan/index.html">Raghu Rajan</a>, <a href="http://ml.informatik.uni-freiburg.de/people/biedenkapp/index.html">André Biedenkapp</a>
-img:                assets/mbrl/mbrl.png
+img:                /assets/mbrl/mbrl.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-04-20-epic.md
+++ b/_posts/2021-04-20-epic.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "An EPIC way to evaluate reward functions"
 date:               2021-04-20  9:00:00
 author:             Adam Gleave, Michael Dennis, Shane Legg, Stuart Russell and Jan Leike<br>
-img:                assets/epic/07_vase.png
+img:                /assets/epic/07_vase.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-05-03-rlsp.md
+++ b/_posts/2021-05-03-rlsp.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Learning What To Do by Simulating the Past"
 date:               2021-05-03  9:00:00
 author:             <a href="https://www.davidlindner.me/">David Lindner</a>, <a href="https://rohinshah.com/">Rohin Shah</a>
-img:                assets/rlsp/cheetah_past_trajectory.png
+img:                /assets/rlsp/cheetah_past_trajectory.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-07-08-basalt.md
+++ b/_posts/2021-07-08-basalt.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "BASALT: A Benchmark for <br> Learning from Human Feedback"
 date:               2021-07-08  9:00:00
 author:             <a href="https://rohinshah.com/">Rohin Shah</a>
-img:                assets/basalt/image15.png
+img:                /assets/basalt/image15.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-07-14-mappo.md
+++ b/_posts/2021-07-14-mappo.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "The Surprising Effectiveness of PPO in Cooperative Multi-Agent Games"
 date:               2021-07-14  9:00:00
 author:             <a href="https://www.linkedin.com/in/akash-velu/">Akash Velu</a> and <a href="">Chao Yu</a> and <a href="https://eugenevinitsky.github.io/">Eugene Vinitsky</a> and <a href="">Yu Wang</a> and <a href="https://bayen.berkeley.edu/">Alexandre Bayen</a> and <a href="https://jxwuyi.weebly.com/">Yi Wu</a>
-img:                assets/mappo/AlphaStar.gif
+img:                /assets/mappo/AlphaStar.gif
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-07-22-spml.md
+++ b/_posts/2021-07-22-spml.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Universal Weakly Supervised Segmentation by Pixel-to-Segment Contrastive Learning"
 date:               2021-07-22  21:00:00
 author:             <a href="https://twke18.github.io/">Tsung-Wei Ke</a> and <a href="https://jyhjinghwang.github.io/">Jyh-Jing Hwang</a> and <a href="http://www1.icsi.berkeley.edu/~stellayu/">Stella X. Yu</a>
-img:                assets/spml/image1.png
+img:                /assets/spml/image1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      True

--- a/_posts/2021-09-15-visual-affordances-robotics.md
+++ b/_posts/2021-09-15-visual-affordances-robotics.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "What Can I Do Here? Learning New Skills by Imagining Visual Affordances"
 date:               2021-09-24  10:00:00
 author:             <a href="">Alexander Khazatsky</a>, <a href="http://ashvin.me/">Ashvin Nair</a>, and <a href="http://people.eecs.berkeley.edu/~svlevine/">Sergey Levine</a>
-img:                assets/visual-affordances-robotics/val_preview.png
+img:                /assets/visual-affordances-robotics/val_preview.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-09-28-wavelet.md
+++ b/_posts/2021-09-28-wavelet.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Distilling neural networks into wavelet models using interpretations"
 date:               2021-09-28  9:00:00
 author:             <a href="https://haywse.github.io/">Wooseok Ha*</a> and <a href="https://csinva.io/">Chandan Singh*</a> and <a href="https://binyu.stat.berkeley.edu/">Bin Yu</a>
-img:                assets/wavelet/fig1.gif
+img:                /assets/wavelet/fig1.gif
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-09-29-ml-safety.md
+++ b/_posts/2021-09-29-ml-safety.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Unsolved ML Safety Problems"
 date:               2021-09-29 7:00:00
 author:             <a href="https://danhendrycks.com/">Dan Hendrycks</a>
-img:                assets/safety/summary_image.png
+img:                /assets/safety/summary_image.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-10-14-forecasting.md
+++ b/_posts/2021-10-14-forecasting.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Updates and Lessons from AI Forecasting"
 date:               2021-10-14  9:00:00
 author:             <a href="https://jsteinhardt.stat.berkeley.edu/">Jacob Steinhardt</a>
-img:                assets/forecasting/hypermind_incumbents.png
+img:                /assets/forecasting/hypermind_incumbents.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-10-22-mural.md
+++ b/_posts/2021-10-22-mural.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Making RL Tractable by Learning More Informative Reward Functions: Example-Based Control, Meta-Learning, and Normalized Maximum Likelihood"
 date:               2021-10-22  10:00:00
 author:             <a href="https://abhishekunique.github.io/">Abhishek Gupta</a>, <a href="http://www.kevintli.com/">Kevin Li</a>, and <a href="http://people.eecs.berkeley.edu/~svlevine/">Sergey Levine</a>
-img:                assets/mural/mural_preview.png
+img:                /assets/mural/mural_preview.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-10-25-coms_mbo.md
+++ b/_posts/2021-10-25-coms_mbo.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Designs from Data: Offline Black-Box Optimization via Conservative Training"
 date:               2021-10-25  13:00:00
 author:             <a href="http://aviralkumar2907.github.io/">Aviral Kumar</a> and <a href="http://young-geng.xyz">Xinyang (Young) Geng</a>
-img:                assets/coms/coms_final.png
+img:                /assets/coms/coms_final.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-10-25-eigenlearning.md
+++ b/_posts/2021-10-25-eigenlearning.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "A First-Principles Theory of Neural<br>Network Generalization"
 date:               2021-10-25  9:00:00
 author:             <a href="https://james-simon.github.io/">Jamie Simon</a>
-img:                assets/eigenlearning/eigenlearning_blog_post_fig1.mp4
+img:                /assets/eigenlearning/eigenlearning_blog_post_fig1.mp4
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-11-03-recon.md
+++ b/_posts/2021-11-03-recon.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "RECON: Learning to Explore the Real World with a Ground Robot"
 date:               2021-11-03  10:00:00
 author:             <a href="https://cs.berkeley.edu/~shah/">Dhruv Shah</a>
-img:                assets/recon/recon_blog_teaser.gif
+img:                /assets/recon/recon_blog_teaser.gif
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-11-08-similarity.md
+++ b/_posts/2021-11-08-similarity.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "How should we compare neural network representations?"
 date:               2021-11-08  12:00:00
 author:             <a href="https://francesding.github.io/">Frances Ding</a> and <a href="https://jsteinhardt.stat.berkeley.edu/">Jacob Steinhardt</a>
-img:                assets/similarity/PWCCA_avg_double_heatmap.png
+img:                /assets/similarity/PWCCA_avg_double_heatmap.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-11-1-epistemic-pomdp.md
+++ b/_posts/2021-11-1-epistemic-pomdp.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Why Generalization in RL is Difficult: Epistemic POMDPs and Implicit Partial Observability"
 date:               2021-11-01  9:00:00
 author:             <a href="https://dibyaghosh.com/">Dibya Ghosh</a>
-img:                assets/epistemic_pomdp/teaser.gif
+img:                /assets/epistemic_pomdp/teaser.gif
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-11-17-bridge-data.md
+++ b/_posts/2021-11-17-bridge-data.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Bridge  Data:  Boosting  Generalization  of  Robotic  Skills  with Cross-Domain  Datasets"
 date:               2021-11-17  9:00:00
 author:             <a href="https://febert.github.io/">Frederik Ebert</a> and <a href="https://yanlai00.github.io">Yanlai Yang</a>
-img:                assets/bridge-data/header_blog_post.png
+img:                /assets/bridge-data/header_blog_post.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-11-19-mi-sufficiency-analysis.md
+++ b/_posts/2021-11-19-mi-sufficiency-analysis.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Which Mutual Information Representation Learning Objectives are Sufficient for Control?"
 date:               2021-11-19  9:00:00
 author:             <a href="https://katerakelly.github.io/">Kate Rakelly</a>
-img:                assets/mi_sufficiency_analysis/image1.png
+img:                /assets/mi_sufficiency_analysis/image1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-11-19-trajectory-transformer.md
+++ b/_posts/2021-11-19-trajectory-transformer.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Sequence Modeling Solutions<br> for Reinforcement Learning Problems"
 date:               2021-11-19  9:00:00
 author:             <a href="https://people.eecs.berkeley.edu/~janner/">Michael Janner</a>
-img:                assets/trajectory-transformer/outlines_transformer.png
+img:                /assets/trajectory-transformer/outlines_transformer.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2021-12-14-unsupervised-rl.md
+++ b/_posts/2021-12-14-unsupervised-rl.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "The Unsupervised Reinforcement Learning Benchmark"
 date:               2021-12-14  12:00:00
 author:             <a href="https://www.mishalaskin.com/edaaae9ed2b54016a66a0e315a9c9f63">Misha Laskin</a> and <a href="https://cs.nyu.edu/~dy1042/">Denis Yarats</a>
-img:                assets/unsupervised_rl/img0.png
+img:                /assets/unsupervised_rl/img0.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2022-02-02-imodels.md
+++ b/_posts/2022-02-02-imodels.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "imodels: leveraging the unreasonable effectiveness of rules"
 date:               2022-2-2  12:00:00
 author:             <a href="https://csinva.io/">Chandan Singh</a> and <a href="https://www.linkedin.com/in/nasseri/">Keyan Nasseri</a> and <a href="https://binyu.stat.berkeley.edu/">Bin Yu</a>
-img:                assets/imodels/imodels_anim.gif
+img:                /assets/imodels/imodels_anim.gif
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2022-02-23-cic.md
+++ b/_posts/2022-02-23-cic.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "Unsupervised Skill Discovery with Contrastive Intrinsic Control"
 date:               2022-02-23  12:00:00
 author:             <a href="https://www.mishalaskin.com/edaaae9ed2b54016a66a0e315a9c9f63">Misha Laskin</a> 
-img:                assets/cic/img1.png
+img:                /assets/cic/img1.png
 excerpt_separator:  <!--more-->
 visible:            True
 show_comments:      False

--- a/_posts/2022-03-21-ukraine-sar-maers.md
+++ b/_posts/2022-03-21-ukraine-sar-maers.md
@@ -91,7 +91,7 @@ Radar waves penetrate clouds, and since the satellite is actively producing the 
 There are multiple SAR satellite constellations in operation at the moment. The [Copernicus Sentinel-1](https://sentinel.esa.int/web/sentinel/missions/sentinel-1) constellation provides imagery to the public at large with resolutions ranging from 10 - 80 meters (10 meter imagery being the most common. Most commercial SAR providers, such as [ICEYE](https://www.iceye.com/) and [Capella Space](https://www.capellaspace.com/), provide imagery down to 0.5 meter resolution. In upcoming launches, other commercial vendors aim to produce SAR imagery with sub-0.5 meter resolution with high revisit rates as satellite constellations grow and government regulations evolve.
 
 <p style="text-align:center;">
-    <img src="https://bair.berkeley.edu/static/blog/maers/sar-ukraine-belarus.webp" width="100%">
+    <img src="https://bair.berkeley.edu/static/blog/maers/sar-ukraine-belarus.jpg" width="100%">
     <br>
     <i><a href="https://www.wired.co.uk/article/ukraine-russia-satellites"><b>Figure 4:</b> A VHR SAR image provided by Capella Space over the Ukraine-Belarus border</a>.</i>
 </p>

--- a/_posts/2022-3-04-ultraviolet.md
+++ b/_posts/2022-3-04-ultraviolet.md
@@ -3,7 +3,7 @@ layout:             post
 title:              "All You Need is LUV: Unsupervised Collection of Labeled Images Using UV-Fluorescent Markings"
 date:               2022-02-23  12:00:00
 author:             <a href="https://bthananjeyan.github.io">Brijen Thananjeyan*</a> and <a href="https://kerrj.github.io/">Justin Kerr*</a> 
-img:                assets/luv/img1.png
+img:                /assets/luv/img1.png
 excerpt_separator:  <!--more-->
 visible:            False
 show_comments:      False


### PR DESCRIPTION
All the `og:image` tags in these posts are broken because they don't include a slash in front of `assets`.